### PR TITLE
ci: use ubuntu 18.04 agent for linux pr job

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -41,6 +41,8 @@ steps:
     npm -f version $(packageBumpType) -m "chore: Bumped to version %s from release pipeline $(succinctAllSkipTokens)"
     export PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version);")
     echo "##vso[task.setVariable variable=packageVersion]$PACKAGE_VERSION"
+    export PACKAGE_NAME=$(node -e "console.log(require('./package.json').name);")
+    echo "##vso[task.setvariable variable=packageName]$PACKAGE_NAME"
     git add package-lock.json
     git commit -n -m "chore: Bumped to version $PACKAGE_VERSION from release pipeline $(succinctAllSkipTokens)"
     git push https://$(githubPat)@github.com/swellaby/azp-bump.git

--- a/.azure-pipelines/pull-requests/lint.yml
+++ b/.azure-pipelines/pull-requests/lint.yml
@@ -4,7 +4,7 @@ pr:
 - master
 
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: 'Ubuntu-18.04'
 
 resources:
   repositories:

--- a/.azure-pipelines/pull-requests/linux.yml
+++ b/.azure-pipelines/pull-requests/linux.yml
@@ -4,7 +4,7 @@ pr:
 - master
 
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: 'Ubuntu-18.04'
 
 resources:
   repositories:

--- a/.azure-pipelines/pull-requests/sonar.yml
+++ b/.azure-pipelines/pull-requests/sonar.yml
@@ -4,7 +4,7 @@ pr:
 - master
 
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: 'Ubuntu-18.04'
 
 resources:
   repositories:


### PR DESCRIPTION
## Changes
Summary of changes included in this PR:
- [x] Use Ubuntu 18.04 on linux and sonar PR jobs
- [x] Fix CI pipeline dynamic vars to properly set tarball name

## Related Issues
- Closes #49 

