### PR TITLE
ci: add functional test pr job

### DIFF
--- a/.azure-pipelines/pull-requests/functional-tests.yml
+++ b/.azure-pipelines/pull-requests/functional-tests.yml
@@ -13,6 +13,10 @@ resources:
     name: swellaby/azure-pipelines-templates
     endpoint: swellaby
 
+# Unfortunately multi-checkout is still not yet supported.
+# The commented out portions below are what we'll be able to switch to
+# once it becomes enabled.
+# https://github.com/microsoft/azure-pipelines-yaml/blob/master/design/multi-checkout.md
 variables:
   testDir: '$(Agent.TempDirectory)/functional-tests'
   # appDir: $(Build.SourcesDirectory)/app
@@ -26,6 +30,7 @@ steps:
 
 - script: |
     git clone https://github.com/swellaby/azp-bump-tests.git $(testDir)
+  displayName: 'Clone functional tests repo'
 
 - script: npm pack
   displayName: 'npm pack'

--- a/.azure-pipelines/pull-requests/functional-tests.yml
+++ b/.azure-pipelines/pull-requests/functional-tests.yml
@@ -56,3 +56,10 @@ steps:
     verbose: false
     customCommand: test
   displayName: 'Run functional tests'
+
+- template: templates/yml/any/publish-test-results.yml@templates
+  parameters:
+    taskDisplayName: 'Publish functional test results'
+    testResultsFiles: 'xunit.xml'
+    searchFolder: $(testDir)/.testresults
+    testRunTitle: 'azp-bump::Functional Tests::Linux PR - Build $(Build.BuildId)'

--- a/.azure-pipelines/pull-requests/functional-tests.yml
+++ b/.azure-pipelines/pull-requests/functional-tests.yml
@@ -13,26 +13,41 @@ resources:
     name: swellaby/azure-pipelines-templates
     endpoint: swellaby
 
+variables:
+  testDir: 'functional-tests'
+  appDir: app
+  appTarballPath: $(Build.SourcesDirectory)/functional-tests/azp-bump-$(packageVersion).tgz
+
 steps:
 - checkout: self
-  path: app
-- checkout: github://swellaby/azp-bump-tests
-  path: 'functional-tests'
+  path: $(appDir)
+# - checkout: github://swellaby/azp-bump-tests
+#   path: 'functional-tests'
+
+- script: |
+    git clone https://github.com/swellaby/azp-bump-tests.git $(testDir)
 
 - script: npm pack
   displayName: 'npm pack'
-  workingDirectory: $(Build.SourcesDirectory)/app
+  workingDirectory: $(appDir)
 
 - script: |
     export PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version);")
     echo "##vso[task.setvariable variable=packageVersion]$PACKAGE_VERSION"
   displayName: 'Extract package version'
-  workingDirectory: $(Build.SourcesDirectory)/app
+  workingDirectory: $(appDir)
 
 - task: Npm@1
   inputs:
     command: custom
-    customCommand: 'run target:install -- $(Build.SourcesDirectory)/functional-tests/azp-bump-$(packageVersion).tgz'
-    workingDir: $(Build.SourcesDirectory)/functional-tests
+    customCommand: 'run target:install -- $(appTarballPath)'
+    workingDir: $(testDir)
   displayName: 'Install app'
 
+- task: Npm@1
+  inputs:
+    command: custom
+    workingDir: '$(testDir)'
+    verbose: false
+    customCommand: test
+  displayName: 'Run functional tests'

--- a/.azure-pipelines/pull-requests/functional-tests.yml
+++ b/.azure-pipelines/pull-requests/functional-tests.yml
@@ -14,13 +14,13 @@ resources:
     endpoint: swellaby
 
 variables:
-  testDir: 'functional-tests'
-  appDir: $(Build.SourcesDirectory)/app
-  appTarballPath: $(Build.SourcesDirectory)/functional-tests/azp-bump-$(packageVersion).tgz
+  testDir: '$(Agent.TempDirectory)/functional-tests'
+  # appDir: $(Build.SourcesDirectory)/app
+  appTarballPath: $(Build.SourcesDirectory)/azp-bump-$(packageVersion).tgz
 
 steps:
-- checkout: self
-  path: $(appDir)
+# - checkout: self
+#   path: $(appDir)
 # - checkout: github://swellaby/azp-bump-tests
 #   path: 'functional-tests'
 
@@ -29,20 +29,25 @@ steps:
 
 - script: npm pack
   displayName: 'npm pack'
-  workingDirectory: $(appDir)
+  # workingDirectory: $(appDir)
 
 - script: |
     export PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version);")
     echo "##vso[task.setvariable variable=packageVersion]$PACKAGE_VERSION"
   displayName: 'Extract package version'
-  workingDirectory: $(appDir)
+  # workingDirectory: $(appDir)
+
+- task: Npm@1
+  inputs:
+    workingDir: $(testDir)
+  displayName: 'Install test dependencies'
 
 - task: Npm@1
   inputs:
     command: custom
     customCommand: 'run target:install -- $(appTarballPath)'
     workingDir: $(testDir)
-  displayName: 'Install app'
+  displayName: 'Prep tests'
 
 - task: Npm@1
   inputs:

--- a/.azure-pipelines/pull-requests/functional-tests.yml
+++ b/.azure-pipelines/pull-requests/functional-tests.yml
@@ -1,0 +1,38 @@
+trigger: none
+
+pr:
+- master
+
+pool:
+  vmImage: 'Ubuntu-18.04'
+
+resources:
+  repositories:
+  - repository: templates
+    type: github
+    name: swellaby/azure-pipelines-templates
+    endpoint: swellaby
+
+steps:
+- checkout: self
+  path: app
+- checkout: github://swellaby/azp-bump-tests
+  path: 'functional-tests'
+
+- script: npm pack
+  displayName: 'npm pack'
+  workingDirectory: $(Build.SourcesDirectory)/app
+
+- script: |
+    export PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version);")
+    echo "##vso[task.setvariable variable=packageVersion]$PACKAGE_VERSION"
+  displayName: 'Extract package version'
+  workingDirectory: $(Build.SourcesDirectory)/app
+
+- task: Npm@1
+  inputs:
+    command: custom
+    customCommand: 'run target:install -- $(Build.SourcesDirectory)/functional-tests/azp-bump-$(packageVersion).tgz'
+    workingDir: $(Build.SourcesDirectory)/functional-tests
+  displayName: 'Install app'
+

--- a/.azure-pipelines/pull-requests/functional-tests.yml
+++ b/.azure-pipelines/pull-requests/functional-tests.yml
@@ -15,7 +15,7 @@ resources:
 
 variables:
   testDir: 'functional-tests'
-  appDir: app
+  appDir: $(Build.SourcesDirectory)/app
   appTarballPath: $(Build.SourcesDirectory)/functional-tests/azp-bump-$(packageVersion).tgz
 
 steps:


### PR DESCRIPTION
## Changes
Summary of changes included in this PR:
- [x] Adds a PR job to run the functional tests (on linux) as part of the PR check, as it only takes ~40 seconds to run these tests

## Related Issues
- Closes #31
