### PR TITLE
Support for whitespace preservation

### DIFF
--- a/bin/azp-bump.js
+++ b/bin/azp-bump.js
@@ -11,6 +11,7 @@ const packageJson = require('../package.json');
 const typeDescription = 'The bump version type. Allowed values: major, minor, or patch.';
 const typeRegex = /^(patch|minor|major)$/i;
 const indentDescription = 'The spacing indent to use while updating the task manifests. Specifying a number will use that many spaces, ' +
+    'preserve means leave the existing indentation in place, ' +
     'or a string to use a tab character. Allowed values: 1-10 (inclusive) OR t, tab, or \'\\t\'.';
 const versionPropertyTypeRegex = /^(string|number)$/i;
 const versionPropertyTypeDescription = 'Controls the property type of the version fields. Allowed values: string, number.';
@@ -23,6 +24,9 @@ const versionPropertyTypeDescription = 'Controls the property type of the versio
 const parseIndent = indent => {
     if (indent === 't' || indent === 'tab' || indent === '\\t') {
         return '\t';
+    }
+    else if(indent === 'preserve') {
+        return indent;
     }
 
     return parseInt(indent);

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ const utils = require('./utils');
  * @property {string} initialVersion - The original version contained in the task manifest file.
  * @property {string} bumpedVersion - The bumped version of the file now in the task manifest file.
  * @property {object} task - The JSON object representation of the task manifest file contents.
+ * @property {string} contents - The JSON string representation of the task manifest file contents.
  */
 
 /**
@@ -77,8 +78,8 @@ const validateFileGlobs = (fileGlobs) => {
  * @private
  * @returns {Promise<BumpedFileResult>}
  */
-const writeBumpedTaskToFile = (bumpedTask, opts) => new Promise((resolve, reject) => {
-    fs.writeFile(bumpedTask.filePath, JSON.stringify(bumpedTask.task, null, opts.indent), err => {
+const writeBumpedTaskToFile = (bumpedTask) => new Promise((resolve, reject) => {
+    fs.writeFile(bumpedTask.filePath, bumpedTask.contents, err => {
         if (!err) {
             const filePath = bumpedTask.filePath;
             const initialVersion = bumpedTask.initialVersion;
@@ -101,10 +102,17 @@ const writeBumpedTaskToFile = (bumpedTask, opts) => new Promise((resolve, reject
 const bumpTaskObjects = (taskManifestFile, opts) => new Promise((resolve, reject) => {
     try {
         const task = JSON.parse(taskManifestFile.fileContents);
+        let contents;
         const initialVersion = utils.getTaskVersion(task);
         const bumpedVersion = utils.bumpVersion(task, initialVersion, opts);
         const filePath = taskManifestFile.filePath;
-        resolve({ filePath, task, initialVersion, bumpedVersion });
+        if(opts.indent == 'preserve'){
+            contents = utils.setVersionInPlace(taskManifestFile.fileContents, opts, bumpedVersion);
+        }
+        else {
+            contents = JSON.stringify(task, null, opts.indent);
+        }
+        resolve({ filePath, task, contents, initialVersion, bumpedVersion });
     } catch (err) {
         reject(err);
     }
@@ -138,7 +146,7 @@ const readTaskManifestFile = (filePath) => new Promise((resolve, reject) => {
 const bumpTaskManifests = (filePaths, opts) => new Promise((resolve, reject) => {
     Promise.all(filePaths.map(filePath => readTaskManifestFile(filePath)))
         .then(manifests => Promise.all(manifests.map(manifest => bumpTaskObjects(manifest, opts)))
-            .then(bumpedTasks => Promise.all(bumpedTasks.map(bumpedTask => writeBumpedTaskToFile(bumpedTask, opts)))
+            .then(bumpedTasks => Promise.all(bumpedTasks.map(writeBumpedTaskToFile))
                 .then(result => resolve(result))))
         .catch(err => reject(err));
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const semver = require('semver');
+const jip = require('json-in-place');
 
 const defaultReleaseType = 'patch';
 const defaultJsonIndent = 2;
@@ -29,6 +30,9 @@ const validateJsonIndent = (opts) => {
 
     if (opts.indent === '\t' || opts.indent === 't' || opts.indent === 'tab') {
         opts.indent = '\t';
+        return;
+    }
+    else if(opts.indent === 'preserve') {
         return;
     }
 
@@ -122,11 +126,39 @@ const bumpVersion = (task, currentVersion, opts) => {
     return bumpedVersion;
 };
 
+/**
+ * Writes the task's updated version into a JSON string with whitespace preservation
+ *
+ * @param {string} fileContents - The task manifest JSON string.
+ * @param {Object} opts - The options for this plugin.
+ * @param {string} bumpedVersion - The bumped version of the task.
+ *
+ * @returns {string} - The JSON string with the task manifest with the bumped version
+ */
+const setVersionInPlace = (fileContents, opts, bumpedVersion) => {
+    let major = semver.major(bumpedVersion);
+    let minor = semver.minor(bumpedVersion);
+    let patch = semver.patch(bumpedVersion);
+
+    if (opts.versionPropertyType === stringVersionPropertyType) {
+        major = major.toString();
+        minor = minor.toString();
+        patch = patch.toString();
+    }
+
+    return jip(fileContents)
+        .set('version.Major', major)
+        .set('version.Minor', minor)
+        .set('version.Patch', patch)
+        .toString();
+};
+
 module.exports = {
     validateOptions,
     validateReleaseType,
     validateJsonIndent,
     validateVersionPropertyType,
     getTaskVersion,
-    bumpVersion
+    bumpVersion,
+    setVersionInPlace
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "commander": "^8.0.0",
         "fancy-log": "^1.3.3",
         "glob": "^7.1.4",
+        "json-in-place": "^1.0.1",
         "semver": "^7.0.0"
       },
       "bin": {
@@ -2723,6 +2724,19 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/json-in-place": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-in-place/-/json-in-place-1.0.1.tgz",
+      "integrity": "sha512-XDFWT1iOlZErTFU0GGRju9g/uzY8BVFVsGsbgiE71Fg2+3c0lK4X4GSRB8PQ527hVkAJ2Z5Qv2sa7Re9iFNYKw==",
+      "dependencies": {
+        "json-lexer": "1.1.1"
+      }
+    },
+    "node_modules/json-lexer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/json-lexer/-/json-lexer-1.1.1.tgz",
+      "integrity": "sha512-kdpvcH1gqYXQEAVFxVwIWZKihrS0o9SjbwW2v8+0p6HA/YSMk5c4BkXdMiz/kDz2QW0XlOSkFKrJsC9KL0Mb5g=="
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -7201,6 +7215,19 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
+    },
+    "json-in-place": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-in-place/-/json-in-place-1.0.1.tgz",
+      "integrity": "sha512-XDFWT1iOlZErTFU0GGRju9g/uzY8BVFVsGsbgiE71Fg2+3c0lK4X4GSRB8PQ527hVkAJ2Z5Qv2sa7Re9iFNYKw==",
+      "requires": {
+        "json-lexer": "1.1.1"
+      }
+    },
+    "json-lexer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/json-lexer/-/json-lexer-1.1.1.tgz",
+      "integrity": "sha512-kdpvcH1gqYXQEAVFxVwIWZKihrS0o9SjbwW2v8+0p6HA/YSMk5c4BkXdMiz/kDz2QW0XlOSkFKrJsC9KL0Mb5g=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "commander": "^8.0.0",
     "fancy-log": "^1.3.3",
     "glob": "^7.1.4",
+    "json-in-place": "^1.0.1",
     "semver": "^7.0.0"
   }
 }

--- a/test/component/lib/index.js
+++ b/test/component/lib/index.js
@@ -217,6 +217,17 @@ suite('index Suite:', () => {
                     done();
                 }).catch(err => done(err));
             });
+
+            test('Should use specified indent when opts has indent set to preserve', done => {
+                const indent = 'preserve';
+                opts.indent = indent;
+                const taskContents = helpers.createBumpedTaskJsonString(helpers.validSampleOneNumericBumpedVersionTaskContents);
+                index.bumpTaskManifestFiles(helpers.singleGlobArgs, opts).then(bumpResult => {
+                    assert.isTrue(fsWriteFileStub.calledWith(helpers.taskOneFilePath, taskContents));
+                    assert.deepEqual(bumpResult.bumpedFiles, helpers.bumpedFileResults);
+                    done();
+                }).catch(err => done(err));
+            });
         });
 
         suite('bump type Suite:', () => {

--- a/test/unit/bin/azp-bump.js
+++ b/test/unit/bin/azp-bump.js
@@ -65,7 +65,8 @@ suite('bin/azp-bump Suite:', () => {
 
         test('Should correctly set indent option', () => {
             const indentDescription = 'The spacing indent to use while updating the task manifests. Specifying a number will use that many spaces, ' +
-                'or a string to use a tab character. Allowed values: 1-10 (inclusive) OR t, tab, or \'\\t\'.';
+            'preserve means leave the existing indentation in place, ' +
+            'or a string to use a tab character. Allowed values: 1-10 (inclusive) OR t, tab, or \'\\t\'.';
             assert.isTrue(commanderOptionSpy.calledWithExactly('-i, --indent [indent]', indentDescription, cli.parseIndent, 2));
         });
 
@@ -151,6 +152,10 @@ suite('bin/azp-bump Suite:', () => {
 
         test('Should return number when specified indent is ten as a string', () => {
             assert.deepEqual(cli.parseIndent('10'), 10);
+        });
+
+        test('Should support indent=preserve', () => {
+            assert.deepEqual(cli.parseIndent('preserve'), 'preserve');
         });
     });
 });

--- a/test/unit/lib/index.js
+++ b/test/unit/lib/index.js
@@ -24,6 +24,7 @@ suite('index Suite:', () => {
     const opts = {};
     const failureErrorMessageBase = 'Fatal error occurred while attempting to bump file. Details: ';
     const noDetailsErrorMessage = failureErrorMessageBase + 'unknown';
+    const bumpedContent = JSON.stringify(helpers.validSampleOneNumericBumpedVersionTaskContents);
 
     setup(() => {
         utilsValidateOptionsStub = sinon.stub(utils, 'validateOptions').callsFake(() => helpers.defaultOptions);
@@ -188,6 +189,19 @@ suite('index Suite:', () => {
                         assert.isTrue(jsonStringifyStub.calledWith(helpers.validSampleOneTaskContents, null, helpers.defaultJsonIndent));
                         assert.isTrue(fsWriteFileStub.firstCall.calledWith(helpers.taskOneFilePath, validTaskFileContents));
                         assert.isTrue(fsWriteFileStub.secondCall.calledWith(helpers.taskTwoFilePath, validTaskFileContents));
+                        done();
+                    }).catch(err => done(err));
+                });
+
+                test('Should call file write operation with correct inputs with whitespace preservation', done => {
+                    //Not sure how to stub json-in-place, it's a single function module
+                    const opts = {indent: 'preserve'};
+                    utilsValidateOptionsStub.callsFake(() => opts);
+                    jsonStringifyStub.restore();
+
+                    index.bumpTaskManifestFiles(helpers.singleGlobArgs, opts).then(() => {
+                        assert.isTrue(fsWriteFileStub.firstCall.calledWith(helpers.taskOneFilePath, bumpedContent));
+                        assert.isTrue(fsWriteFileStub.secondCall.calledWith(helpers.taskTwoFilePath, bumpedContent));
                         done();
                     }).catch(err => done(err));
                 });


### PR DESCRIPTION
## Changes
Summary of changes included in this PR:
- `preserve` is a valid, special case value for the -i option, it makes the bump preserve existing whitespace and indentation in  the target task.json

## Issues Completed
- Closes #112


EDIT: I was wrong about the space between "Patch" and the number not being preserved. There was some interference on my end. Fix the comment if you'd like.
